### PR TITLE
move user and group definitions

### DIFF
--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -2,9 +2,6 @@
 # RHEL/CentOS only. Set a repository to use for PostgreSQL installation.
 postgresql_enablerepo: ""
 
-postgresql_user: postgres
-postgresql_group: postgres
-
 postgresql_unix_socket_directories:
   - /var/run/postgresql
 

--- a/vars/postgresql.yml
+++ b/vars/postgresql.yml
@@ -1,6 +1,8 @@
 # (c) 2016 DataNexus Inc.  All Rights Reserved.
 ---
 application: postgresql
+postgresql_user: postgres
+postgresql_group: postgres
 postgresql_major_version: 9
 postgresql_minor_version: 6
 postgresql_rev_version: "5-1"


### PR DESCRIPTION
Minor change to support operations overlays. operations playbooks can expect to have all necessary variables defined *only* in the applications variables directory.