### PR TITLE
public internal interface ACL should be closed by default

### DIFF
--- a/roles/aws/tasks/launch-vm.yml
+++ b/roles/aws/tasks/launch-vm.yml
@@ -42,7 +42,7 @@
 - set_fact:
     public_interface_acl: "{{ sg_closed.group_id }}"
   when:
-    - sg_ssh_private is defined
+    - sg_closed is defined
 
 - block:    
   - name: POSTGRESQL OVERLAY | searching for CentOS 7 AMI for specified region

--- a/roles/aws/tasks/launch-vm.yml
+++ b/roles/aws/tasks/launch-vm.yml
@@ -25,7 +25,25 @@
     private_interface_acl: "{{ sg_ssh_private.group_id }}"
   when:
     - sg_ssh_private is defined
-      
+
+- name: POSTGRESQL OVERLAY | creating closed security group
+  local_action:
+    module: ec2_group
+    name: "dnsg_{{ project }}_closed"
+    description: "restrict all inbound and unrestricted egress rules (ansible)"
+    vpc_id: "{{ specified_vpc.vpcs.0.id }}"
+    region: "{{ region }}"
+    rules_egress:
+      # Allow all outbound
+      - proto: all
+        cidr_ip: 0.0.0.0/0
+  register: sg_closed
+
+- set_fact:
+    public_interface_acl: "{{ sg_closed.group_id }}"
+  when:
+    - sg_ssh_private is defined
+
 - block:    
   - name: POSTGRESQL OVERLAY | searching for CentOS 7 AMI for specified region
     ec2_ami_find:
@@ -43,7 +61,7 @@
   when:
     - image is not defined
 
-- name: POSTGRESQL OVERLAY | setting {{ key_path }}
+- name: POSTGRESQL OVERLAY | setting key path to {{ key_path }}
   set_fact: key_path="{{ ansible_env.PWD }}"
   when: key_path is not defined
   
@@ -170,12 +188,12 @@
     subnet_id: "{{ external_subnet_id }}"
     device_index: 1
     attached: true
-    security_groups: "{{ sg_postgresql.group_id }}"
+    security_groups: "{{ public_interface_acl }}"
     state: present
   register: public_eni
   with_items: "{{ ec2.instances }}"
   when:
-    - not ec2|skipped and ec2.changed and ec2.instances|length > 0
+    - not ec2 | skipped and ec2.changed and ec2.instances | length > 0
     - external_subnet_id is defined
 
 - name: POSTGRESQL OVERLAY | configuring public internal ENI to delete on termination


### PR DESCRIPTION
Closed public internal interface by default. While the logical conclusion is the same as creating it with the postgres rules, we prefer to created closed, then open for postgres, which functionally matches the commercial platform.