### PR TITLE
add additional clarification around task names

### DIFF
--- a/roles/master-streaming/tasks/main.yml
+++ b/roles/master-streaming/tasks/main.yml
@@ -4,7 +4,7 @@
 ---
 - block:
   # this needs to be the internal public network 
-  - name: POSTGRESQL OVERLAY | configure replication user authentication
+  - name: POSTGRESQL MASTER OVERLAY | configure replication user authentication
     lineinfile:
       dest: "{{ postgresql_config_path }}/pg_hba.conf"
       line: "host     replication     replicator      {{ hostvars[item].postgresql_interface_ipv4 }}/32         md5"
@@ -12,7 +12,7 @@
     with_items: "{{ groups.postgresql_replica }}"
     notify: restart postgresql  
      
-  - name: POSTGRESQL OVERLAY | adding replication user
+  - name: POSTGRESQL MASTER OVERLAY | adding replication user
     postgresql_user:
       name: "{{ item.name }}"
       password: "{{ item.password | default(omit) }}"
@@ -29,7 +29,7 @@
     no_log: true
     become_user: "{{ postgresql_user }}"
   
-  - name: POSTGRESQL OVERLAY | configuring write ahead log for streaming
+  - name: POSTGRESQL MASTER OVERLAY | configuring write ahead log for streaming
     lineinfile:
       dest: "{{ postgresql_config_path }}/postgresql.conf"
       regexp: "^#wal_level"
@@ -40,7 +40,7 @@
   # max_wal_senders should be four times the total number of replicas 
   - set_fact: wal_senders={{ groups['postgresql_replica'] | length * 4 }}  
   
-  - name: POSTGRESQL OVERLAY | configuring write ahead log senders
+  - name: POSTGRESQL MASTER OVERLAY | configuring write ahead log senders
     lineinfile:
       dest: "{{ postgresql_config_path }}/postgresql.conf"
       regexp: "^#max_wal_senders"
@@ -48,7 +48,7 @@
       line: "max_wal_senders = {{ wal_senders }} \t\t# max number of walsender processes"
     notify: restart postgresql
 
-  - name: POSTGRESQL OVERLAY | configuring checkpoint segments
+  - name: POSTGRESQL MASTER OVERLAY | configuring checkpoint segments
     lineinfile:
       dest: "{{ postgresql_config_path }}/postgresql.conf"
       regexp: "^#checkpoint_segments"
@@ -56,7 +56,7 @@
       line: "checkpoint_segments = 8\t\t\t# in logfile segments, min 1, 16MB each"
     notify: restart postgresql
     
-  - name: POSTGRESQL OVERLAY | configuring write ahead log keep segments
+  - name: POSTGRESQL MASTER OVERLAY | configuring write ahead log keep segments
     lineinfile:
       dest: "{{ postgresql_config_path }}/postgresql.conf"
       regexp: "^#wal_keep_segments"

--- a/roles/replica-streaming/tasks/main.yml
+++ b/roles/replica-streaming/tasks/main.yml
@@ -3,16 +3,16 @@
 # streaming tasks for the replica
 ---
 - block:
-    - name: POSTGRESQL OVERLAY | preserving postgresql.conf
+    - name: POSTGRESQL REPLICA OVERLAY | preserving postgresql.conf
       command: /bin/cp {{ postgresql_config_path }}/postgresql.conf /tmp
       become_user: "{{ postgresql_user }}"
        
-    - name: POSTGRESQL OVERLAY | removing data directory in preparation for streaming
+    - name: POSTGRESQL REPLICA OVERLAY | removing data directory in preparation for streaming
       file:
         path: "{{ postgresql_data_dir }}"  
         state: absent
 
-    - name: POSTGRESQL OVERLAY | ensuring PostgreSQL data directory exists.
+    - name: POSTGRESQL REPLICA OVERLAY | ensuring PostgreSQL data directory exists.
       file:
         path: "{{ postgresql_data_dir }}"
         owner: "{{ postgresql_user }}"
@@ -20,7 +20,7 @@
         state: directory
         mode: 0700
     
-    - name: POSTGRESQL OVERLAY | ensuring PostgreSQL preferences directory exists
+    - name: POSTGRESQL REPLICA OVERLAY | ensuring PostgreSQL preferences directory exists
       file:
         path: "{{ postgresql_home_dir }}/.postgresql"
         owner: "{{ postgresql_user }}"
@@ -28,7 +28,7 @@
         state: directory
         mode: 0700      
     
-    - name: POSTGRESQL OVERLAY | building postgresql password file
+    - name: POSTGRESQL REPLICA OVERLAY | building postgresql password file
       blockinfile:
         name: "{{ postgresql_home_dir }}/.pgpass"
         mode: 0600
@@ -37,16 +37,16 @@
           {{ hostvars[groups.postgresql_master.0].postgresql_interface_ipv4 }}:5432:*:replicator:replicator
       become_user: "{{ postgresql_user }}"
               
-    - name: POSTGRESQL OVERLAY | copying initial database
+    - name: POSTGRESQL REPLICA OVERLAY | copying initial database
       command: /bin/pg_basebackup -h {{ hostvars[item].postgresql_interface_ipv4  }} -D {{ postgresql_data_dir }} -U replicator -v -P --xlog-method=stream
       become_user: "{{ postgresql_user }}"
       with_items: "{{ groups.postgresql_master }}"
       
-    - name: POSTGRESQL OVERLAY | restoring postgresql.conf
+    - name: POSTGRESQL REPLICA OVERLAY | restoring postgresql.conf
       command: /bin/cp /tmp/postgresql.conf {{ postgresql_config_path }}
       become_user: "{{ postgresql_user }}"
    
-    - name: POSTGRESQL OVERLAY | building recovery file
+    - name: POSTGRESQL REPLICA OVERLAY | building recovery file
       blockinfile:
         name: "{{ postgresql_config_path }}/recovery.conf"
         mode: 0600
@@ -58,10 +58,10 @@
       become_user: "{{ postgresql_user }}"
       with_items: "{{ groups.postgresql_master }}"
       
-    - name: POSTGRESQL OVERLAY | fixing SE Linux labels on {{ postgresql_data_dir }}
+    - name: POSTGRESQL REPLICA OVERLAY | fixing SE Linux labels on {{ postgresql_data_dir }}
       command: /usr/sbin/fixfiles -F restore "{{ postgresql_data_dir }}"
 
-    - name: POSTGRESQL OVERLAY | configuring write ahead log for streaming
+    - name: POSTGRESQL REPLICA OVERLAY | configuring write ahead log for streaming
       lineinfile:
         dest: "{{ postgresql_config_path }}/postgresql.conf"
         regexp: "^#wal_level"
@@ -69,7 +69,7 @@
         line: "wal_level = hot_standby\t\t\t# minimal, archive, or hot_standby"
       notify: restart postgresql
 
-    - name: POSTGRESQL OVERLAY | turning on hot standby
+    - name: POSTGRESQL REPLICA OVERLAY | turning on hot standby
       lineinfile:
         dest: "{{ postgresql_config_path }}/postgresql.conf"
         regexp: "^#hot_standby ="
@@ -77,7 +77,7 @@
         line: "hot_standby = on\t\t\t# \"on\" allows queries during recovery"
       notify: restart postgresql
 
-    - name: POSTGRESQL OVERLAY | configuring write ahead log senders
+    - name: POSTGRESQL REPLICA OVERLAY | configuring write ahead log senders
       lineinfile:
         dest: "{{ postgresql_config_path }}/postgresql.conf"
         regexp: "^#max_wal_senders"
@@ -85,7 +85,7 @@
         line: "max_wal_senders = 3\t\t# max number of walsender processes"
       notify: restart postgresql
 
-    - name: POSTGRESQL OVERLAY | configuring checkpoint segments
+    - name: POSTGRESQL REPLICA OVERLAY | configuring checkpoint segments
       lineinfile:
         dest: "{{ postgresql_config_path }}/postgresql.conf"
         regexp: "^#checkpoint_segments"
@@ -93,7 +93,7 @@
         line: "checkpoint_segments = 8\t\t\t# logfile segments, min 1, 16MB each"
       notify: restart postgresql
 
-    - name: POSTGRESQL OVERLAY | configuring write ahead log keep segments
+    - name: POSTGRESQL REPLICA OVERLAY | configuring write ahead log keep segments
       lineinfile:
         dest: "{{ postgresql_config_path }}/postgresql.conf"
         regexp: "^#wal_keep_segments"


### PR DESCRIPTION
Add in some clarification to the ansible names (mater and replica) so to make visual debugging of the output slightly easier.

No logic changes.