### PR TITLE
remove public IPs from data interface

### DIFF
--- a/cleanup-postgresql
+++ b/cleanup-postgresql
@@ -131,21 +131,6 @@
           - "{{ project }}_{{ application }}_replica1_internal"
           - "{{ project }}_{{ application }}_replica1_external"
 
-      - name: POSTGRESQL CLEANUP | deleting public ips
-        azure_rm_publicipaddress:
-          resource_group: "{{ specified_resourcegroup.name }}"
-          name: "{{ item }}"
-          state: absent
-        with_items:
-          - "{{ project }}_{{ application }}"
-          - "{{ project }}_{{ application }}_internal_ip"
-          - "{{ project }}_{{ application }}_external_ip"
-          - "{{ project }}_{{ application }}_master_internal_ip"
-          - "{{ project }}_{{ application }}_master_external_ip"
-          - "{{ project }}_{{ application }}_replica1_internal_ip"
-          - "{{ project }}_{{ application }}_replica1_external_ip"
-          - "{{ project }}_{{ application }}_replica2_internal_ip"
-          - "{{ project }}_{{ application }}_replica2_external_ip"
       - name: POSTGRESQL OVERLAY | deleting all security groups
         azure_rm_securitygroup:
           resource_group: "{{ specified_resourcegroup.name }}"

--- a/roles/azure/tasks/launch-vm.yml
+++ b/roles/azure/tasks/launch-vm.yml
@@ -85,7 +85,6 @@
       security_group: "dnsg_{{ project }}_closed"
       ip_configurations:
         - name: ipconfig1
-          public_ip_address_name: "{{ project }}_{{ application }}_external_ip"
           primary: yes
       tags:
         Application: "{{ application }}"
@@ -130,7 +129,6 @@
       security_group: "dnsg_{{ project }}_closed"
       ip_configurations:
         - name: ipconfig1
-          public_ip_address_name: "{{ project }}_{{ application }}_master_external_ip"
           primary: yes
       tags:
         Application: "{{ application }}"
@@ -159,7 +157,6 @@
       security_group: "dnsg_{{ project }}_closed"
       ip_configurations:
         - name: ipconfig1
-          public_ip_address_name: "{{ project }}_{{ application }}_replica1_external_ip"
           primary: yes
       tags:
         Application: "{{ application }}"


### PR DESCRIPTION
Credit to @KLyversnht and @CSelvaraj2010 for pointing out that Azure networking is interesting.

Public IPs on private NAT interfaces are *not* required to route publicly in Azure. Microsoft must do something behind the scenes on the hypervisor level to allow public routing with an implied internet gateway.

Removed all public IP configurations from PostgreSQL bringup and cleanup.